### PR TITLE
Fix GROUP_CONCAT() not returning null if empty

### DIFF
--- a/classes/adapter_pdosqlite.php
+++ b/classes/adapter_pdosqlite.php
@@ -227,6 +227,9 @@ class helper_plugin_sqlite_adapter_pdosqlite extends helper_plugin_sqlite_adapte
             return null;
         }
         $context['data'] = array_unique($context['data']);
+        if (empty($context['data'][0])) {
+            return null;
+        }
         return join($context['sep'], $context['data']);
     }
 


### PR DESCRIPTION
:exclamation:  This might break existing installations. :exclamation: 

GROUP_CONCAT used to return empty string instead of null.
#### ToDo:
- [ ] testing
