### PR TITLE
make sure that the plugin remains serializable

### DIFF
--- a/_test/sqlite_helper_abstract.test.php
+++ b/_test/sqlite_helper_abstract.test.php
@@ -6,10 +6,10 @@
  * @group plugins
  */
 class sqlite_helper_abstract_test extends DokuWikiTest {
-    function setup() {
+    function setUp() {
         $this->pluginsEnabled[] = 'data';
         $this->pluginsEnabled[] = 'sqlite';
-        parent::setup();
+        parent::setUp();
     }
 
     /**
@@ -252,5 +252,19 @@ EOF;
 
         $this->assertSame(0, $SqliteHelper->countChanges(false), 'Empty result');
         $this->assertEquals(1, $SqliteHelper->countChanges($SqliteHelper->res), 'Insert result');
+    }
+
+    function test_serialize() {
+        $SqliteHelper = $this->getSqliteHelper();
+
+        $res = $SqliteHelper->query('SELECT * FROM testdata');
+        $this->assertNotFalse($res);
+        $SqliteHelper->res_close($res);
+
+        $obj = unserialize(serialize($SqliteHelper));
+
+        $res = $obj->query('SELECT * FROM testdata');
+        $this->assertNotFalse($res);
+        $obj->res_close($res);
     }
 }

--- a/classes/adapter.php
+++ b/classes/adapter.php
@@ -485,6 +485,24 @@ abstract class helper_plugin_sqlite_adapter {
      */
     public abstract function countChanges($res);
 
+    /**
+     * Do not serialize the DB connection
+     *
+     * @return array
+     */
+    public function __sleep() {
+        $this->db = null;
+        return array_keys(get_object_vars($this));
+    }
+
+    /**
+     * On deserialization, reinit database connection
+     */
+    public function __wakeup() {
+        $init = false;
+        $this->initdb($this->dbname, $init);
+    }
+
 }
 
 // vim:ts=4:sw=4:et:enc=utf-8:


### PR DESCRIPTION
this is achived by not serializing the DB connection ressource, but
instead reinitializing it on wakeup.

See https://github.com/cosmocode/dokuwiki-plugin-struct/issues/173