### PR TITLE
add import/export to admin interface

### DIFF
--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -8,3 +8,8 @@ $lang['table'] = 'list tables';
 
 $lang['rename2to3']  = 'Rename %s.sqlite to *.sqlite3';
 $lang['convert2to3'] = 'Convert %s from Sqlite2 to Sqlite3 format';
+
+$lang['export'] = 'export database';
+$lang['import'] = 'import database';
+$lang['import_no_file'] = 'Select file';
+$lang['import_success'] = 'Database imported successfully';


### PR DESCRIPTION
Sometimes I need access to my sqlite databases on a hosting where I don't have the file-level access. This import/export feature is very helpful in this case.