### PR TITLE
Fix missing OR REPLACE in storeEntry() helper method

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -537,7 +537,7 @@ class helper_plugin_sqlite extends DokuWiki_Plugin {
         $keys = join(',', array_keys($entry));
         $vals = join(',', array_fill(0,count($entry),'?'));
 
-        $sql = "INSERT INTO $table ($keys) VALUES ($vals)";
+        $sql = "INSERT OR REPLACE INTO $table ($keys) VALUES ($vals)";
         return $this->query($sql, array_values($entry));
     }
 


### PR DESCRIPTION
Fixes #62

A method parameter could be added to switch between strict `INSERT` and `INSERT OR REPLACE` statements, but I don't think it's necessary.