### PR TITLE
Backward compatibility fixes

### DIFF
--- a/SQLiteDB.php
+++ b/SQLiteDB.php
@@ -94,10 +94,22 @@ class SQLiteDB
     /**
      * Direct access to the PDO object
      * @return \PDO
+     *
      */
     public function pdo()
     {
         return $this->pdo;
+    }
+
+    /**
+     * Alias for backwards compatibility.
+     *
+     * @return \PDO
+     *
+     * @deprecated 2023-03-15
+     */
+    public function getDb() {
+        return $this->pdo();
     }
 
     /**

--- a/SQLiteDB.php
+++ b/SQLiteDB.php
@@ -94,7 +94,6 @@ class SQLiteDB
     /**
      * Direct access to the PDO object
      * @return \PDO
-     *
      */
     public function pdo()
     {

--- a/SQLiteDB.php
+++ b/SQLiteDB.php
@@ -95,20 +95,8 @@ class SQLiteDB
      * Direct access to the PDO object
      * @return \PDO
      */
-    public function pdo()
-    {
-        return $this->pdo;
-    }
-
-    /**
-     * Alias for backwards compatibility.
-     *
-     * @return \PDO
-     *
-     * @deprecated 2023-03-15
-     */
     public function getDb() {
-        return $this->pdo();
+        return $this->pdo;
     }
 
     /**

--- a/_test/SQLiteDBTest.php
+++ b/_test/SQLiteDBTest.php
@@ -33,7 +33,7 @@ class SQLiteDBTest extends DokuWikiTest
     public function testDB()
     {
         $db = new SQLiteDB('testdb', DOKU_PLUGIN . "sqlite/_test/db");
-        $this->assertInstanceOf(\PDO::class, $db->pdo());
+        $this->assertInstanceOf(\PDO::class, $db->getDb());
     }
 
     public function testQuery()

--- a/helper.php
+++ b/helper.php
@@ -10,6 +10,20 @@ use dokuwiki\plugin\sqlite\SQLiteDB;
 use dokuwiki\plugin\sqlite\Tools;
 
 
+
+/**
+ * For compatibility with previous adapter implementation.
+ */
+if(!defined('DOKU_EXT_PDO')) define('DOKU_EXT_PDO', 'pdo');
+class helper_plugin_sqlite_adapter_dummy
+{
+    public function getName() {
+        return DOKU_EXT_PDO;
+    }
+
+    public function setUseNativeAlter($set) {}
+}
+
 /**
  * DokuWiki Plugin sqlite (Helper Component)
  *
@@ -33,6 +47,7 @@ class helper_plugin_sqlite extends DokuWiki_Plugin
         if (!$this->existsPDOSqlite()) {
             msg('PDO SQLite support missing in this PHP install - The sqlite plugin will not work', -1);
         }
+        $this->adapter = new helper_plugin_sqlite_adapter_dummy();
     }
 
     /**
@@ -74,7 +89,7 @@ class helper_plugin_sqlite extends DokuWiki_Plugin
      */
     public function init($dbname, $updatedir)
     {
-        if(!DOKU_UNITTEST) { // for now we don't want to trigger the deprecation warning in the tests
+        if(!defined('DOKU_UNITTEST')) { // for now we don't want to trigger the deprecation warning in the tests
             dbg_deprecated(SQLiteDB::class);
         }
 

--- a/helper.php
+++ b/helper.php
@@ -159,6 +159,14 @@ class helper_plugin_sqlite extends DokuWiki_Plugin
         $args = func_get_args();
         $sql = array_shift($args);
 
+        // check if args contains single array
+        if (isset($args[0]) && is_array($args[0])) {
+            $args = $args[0];
+        }
+
+        // clear the cache
+        $this->data = null;
+
         try {
             return $this->adapter->query($sql, $args);
         } catch (\Exception $e) {

--- a/helper.php
+++ b/helper.php
@@ -118,7 +118,7 @@ class helper_plugin_sqlite extends DokuWiki_Plugin
      */
     public function create_function($function_name, $callback, $num_args)
     {
-        $this->adapter->pdo()->sqliteCreateFunction($function_name, $callback, $num_args);
+        $this->adapter->getDb()->sqliteCreateFunction($function_name, $callback, $num_args);
     }
 
     // region query and result handling functions
@@ -310,7 +310,7 @@ class helper_plugin_sqlite extends DokuWiki_Plugin
      */
     public function quote_and_join($vals, $sep = ',')
     {
-        $vals = array_map([$this->adapter->pdo(), 'quote'], $vals);
+        $vals = array_map([$this->adapter->getDb(), 'quote'], $vals);
         return join($sep, $vals);
     }
 
@@ -319,7 +319,7 @@ class helper_plugin_sqlite extends DokuWiki_Plugin
      */
     public function quote_string($string)
     {
-        return $this->adapter->pdo()->quote($string);
+        return $this->adapter->getDb()->quote($string);
     }
 
     /**
@@ -327,7 +327,7 @@ class helper_plugin_sqlite extends DokuWiki_Plugin
      */
     public function escape_string($str)
     {
-        return trim($this->adapter->pdo()->quote($str), "'");
+        return trim($this->adapter->getDb()->quote($str), "'");
     }
 
     // endregion


### PR DESCRIPTION
This commit fixes some backward compatibility issues with #73 but some more actions are required.

This commit creates a dummy adapter class which is used as $this->adapter in SQLiteDB instead of null. This behaviour is required by struct db helper and all my db plugins (approve, ireadit, bez, notification) which followed the struct's helper/db.php. This is required because we check if the adapter is not null before calling init method.

It also introduces the getDb method as a alias for pdo(). From my perspective it is used only in bez plugin but this also can be used by other sqlite-based plugins.

Unfortunately there are still some other issues with the new adapter. I've already caught two:

1.   Workaround for res2arr and res2count doesn't work properly. Since the helper plugin is singleton the $this->data is kept between different queries and returns wrong results when we call the res2arr method on different resources.
2. The migration of struct plugin from 18 to 19 don't want to finish. I didn't check it  closely but it may be related to the 1 issue.

