### PR TITLE
two additional events: PLUGIN_SQLITE_QUERY_SAVE, PLUGIN_SQLITE_QUERY_DELETE

### DIFF
--- a/QuerySaver.php
+++ b/QuerySaver.php
@@ -2,6 +2,8 @@
 
 namespace dokuwiki\plugin\sqlite;
 
+use dokuwiki\Extension\Event;
+
 class QuerySaver
 {
 
@@ -25,8 +27,18 @@ class QuerySaver
      */
     public function saveQuery($name, $query)
     {
-        $sql = 'INSERT INTO queries (db, name, sql) VALUES (?, ?, ?)';
-        $this->db->exec($sql, [$this->upstream, $name, $query]);
+        $eventData = [
+            'sqlitedb' => $this->db,
+            'upstream'  => $this->upstream,
+            'name' => &$name,
+            'query' => &$query
+        ];
+        $event = new Event('PLUGIN_SQLITE_QUERY_SAVE', $eventData);
+        if ($event->advise_before()) {
+            $sql = 'INSERT INTO queries (db, name, sql) VALUES (?, ?, ?)';
+            $this->db->exec($sql, [$this->upstream, $name, $query]);
+        }
+        $event->advise_after();
     }
 
     /**
@@ -48,8 +60,17 @@ class QuerySaver
      */
     public function deleteQuery($name)
     {
-        $sql = 'DELETE FROM queries WHERE db = ? AND name = ?';
-        $this->db->exec($sql, [$this->upstream, $name]);
+        $eventData = [
+            'sqlitedb' => $this->db,
+            'upstream'  => $this->upstream,
+            'name' => &$name
+        ];
+        $event = new Event('PLUGIN_SQLITE_QUERY_DELETE', $eventData);
+        if ($event->advise_before()) {
+            $sql = 'DELETE FROM queries WHERE db = ? AND name = ?';
+            $this->db->exec($sql, [$this->upstream, $name]);
+        }
+        $event->advise_after();
     }
 
     /**

--- a/deleted.files
+++ b/deleted.files
@@ -1,0 +1,11 @@
+# This is a list of files that were present in previous plugin releases
+# but were removed later. An up to date plugin should not have any of
+# the files installed
+
+_test/AbstractTest.php
+_test/Sqlite2Test.php
+classes/adapter.php
+classes/adapter_null.php
+classes/adapter_pdosqlite.php
+classes/adapter_sqlite2.php
+classes/


### PR DESCRIPTION
This commit adds two additional events to sqlite plugin. I've found this events necessary for my sql2wiki plugin but they can be generally useful for everyone developing a plugin that make use of saved queries.